### PR TITLE
fixed a bug, whre has_detail is only set for new Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 
 ####  Released
+## v1.2.0 - 2017-12-12
+### Changed, going to the first Stable Major Vesion
+ 
  
 ## v1.1.0-rc.2 - 2017-12-09
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "itscoding/facebook-connector",
-    "description": "Connect a Website to an Facbook Page",
+    "description": "Connect a Website to an Facebook Page",
     "type": "craft-plugin",
-    "version": "1.1.0-rc.2",
+    "version": "1.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/assetbundles/facebookconnector/dist/img/FacebookConnector-icon.svg
+++ b/src/assetbundles/facebookconnector/dist/img/FacebookConnector-icon.svg
@@ -1,52 +1,92 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="99.012px" height="99.012px" viewBox="0 0 99.012 99.012" style="enable-background:new 0 0 99.012 99.012;"
-	 xml:space="preserve">
-<g>
-	<g>
-		<path d="M25.08,15.648c-0.478-0.478-1.135-0.742-1.805-0.723c-0.675,0.017-1.314,0.309-1.768,0.808
-			c-14.829,16.325-6.762,51.623-5.916,55.115L0.723,85.717C0.26,86.18,0,86.808,0,87.463c0,0.654,0.26,1.283,0.723,1.746
-			l8.958,8.957c0.482,0.48,1.114,0.723,1.746,0.723c0.631,0,1.264-0.24,1.745-0.723l14.865-14.864
-			c7.237,1.859,16.289,2.968,24.28,2.968c9.599,0,22.739-1.543,30.836-8.886c0.5-0.454,0.793-1.093,0.809-1.769
-			c0.018-0.676-0.245-1.328-0.723-1.805L25.08,15.648z"/>
-		<path d="M46.557,30.345c0.482,0.482,1.114,0.723,1.746,0.723c0.632,0,1.264-0.241,1.746-0.724l18.428-18.428
-			c1.305-1.305,2.023-3.04,2.023-4.885c0-1.846-0.719-3.582-2.023-4.886c-1.305-1.305-3.039-2.022-4.885-2.022
-			c-1.845,0-3.581,0.718-4.887,2.022L40.277,20.574c-0.964,0.964-0.964,2.527,0,3.492L46.557,30.345z"/>
-		<path d="M96.99,30.661c-1.305-1.305-3.039-2.024-4.885-2.024c-1.847,0-3.582,0.718-4.886,2.023L68.79,49.089
-			c-0.464,0.463-0.724,1.091-0.724,1.746s0.26,1.282,0.724,1.746l6.28,6.278c0.481,0.482,1.113,0.724,1.746,0.724
-			c0.631,0,1.264-0.241,1.746-0.724l18.43-18.429C99.686,37.735,99.686,33.353,96.99,30.661z"/>
-	</g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:cc="http://creativecommons.org/ns#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:svg="http://www.w3.org/2000/svg"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+        xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+        width="14mm"
+        height="14mm"
+        viewBox="0 0 14 14.000001"
+        version="1.1"
+        id="svg8"
+        inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+        sodipodi:docname="icon.svg">
+  <defs
+          id="defs2" />
+  <sodipodi:namedview
+          id="base"
+          pagecolor="#ffffff"
+          bordercolor="#666666"
+          borderopacity="1.0"
+          inkscape:pageopacity="0.0"
+          inkscape:pageshadow="2"
+          inkscape:zoom="7.9195959"
+          inkscape:cx="4.9054905"
+          inkscape:cy="13.126067"
+          inkscape:document-units="mm"
+          inkscape:current-layer="layer1"
+          showgrid="false"
+          inkscape:window-width="3840"
+          inkscape:window-height="2066"
+          inkscape:window-x="-11"
+          inkscape:window-y="-11"
+          inkscape:window-maximized="1" />
+  <metadata
+          id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+              rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+                rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+          inkscape:label="Ebene 1"
+          inkscape:groupmode="layer"
+          id="layer1"
+          transform="translate(-1.5013499,-1.3647326)">
+    <path
+            id="Shape-7"
+            d="m 3.7489399,7.832674 v 0 0 l -0.05429,0.252514 H 2.9455131 L 3.1644439,7.069603 C 3.2160479,6.6864875 3.8764159,6.802442 3.9748289,6.824196 L 4.0803129,6.33482 C 2.8927714,5.9315297 2.5460904,7.069603 2.5460904,7.069603 L 2.3272408,8.085188 h -0.00382 L 1.5796743,8.600483 H 2.2162314 L 1.5166118,11.844038 H 2.1350466 L 2.8342598,8.600483 h 0.7491111 0.618434 C 4.027733,9.524885 5.1232462,9.3739767 5.4577372,9.3145987 v 0 C 4.6576722,9.4742067 4.6629301,9.2019882 4.6629301,9.2019882 L 4.2018049,8.600483 4.6629301,9.2019882 4.2018049,8.600483 3.6946499,8.085188 Z"
+            inkscape:connector-curvature="0"
+            style="fill:#3b589e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.12801209"
+            sodipodi:nodetypes="cccccccccccccccccccccccccc" />
+    <g
+            id="Page-1"
+            transform="matrix(0.08126607,0,0,0.07179818,3.3454403,5.1282119)"
+            style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1.67586744">
+      <g
+              id="craft-cms-logo"
+              style="fill:#d95947;stroke-width:1.67586744">
+        <path
+                id="Shape"
+                d="m 140.254,16.15 h -0.041 l -8.899,6.98 -0.668,3.517 h -9.218 l 2.694,-14.145 c 0.635,-5.336 8.761,-3.721 9.972,-3.418 l 1.298,-6.816 c -14.613,-5.617 -18.879,10.234 -18.879,10.234 l -2.693,14.145 h -0.047 l -9.152,7.177 h 7.833 L 103.845,79 h 7.61 l 8.604,-45.176 h 9.218 l -3.369,17.684 c -2.142,12.875 10.753,11.465 14.869,10.638 l 1.287,-6.743 c -9.845,2.223 -8.547,-3.895 -8.547,-3.895 l 3.37,-17.684 h 11.734 l 1.367,-7.177 h -11.734 z"
+                inkscape:connector-curvature="0"
+                style="stroke-width:1.67586744" />
+        <path
+                id="path4592"
+                d="m 79.92,26.819 -1.375,7.611 c 18.595,-8.104 15.462,6.015 15.462,6.015 l -0.38,2.123 c 0,0 -10.902,-5.596 -18.534,0.635 0,0 -4.47,2.98 -4.47,8.941 0,5.962 5.464,9.166 5.464,9.166 0,0 8.218,4.336 14.653,-2.594 l -0.71,3.225 h 7.197 L 101.75,40.486 C 105.145,19.316 79.92,26.819 79.92,26.819 Z m 11.956,25.548 c -7.918,8.125 -12.989,2.804 -12.989,2.804 -3.433,-3.342 0.361,-6.774 0.361,-6.774 5.238,-4.787 13.253,0.473 13.253,0.473 z"
+                inkscape:connector-curvature="0"
+                style="stroke-width:1.67586744" />
+        <path
+                id="path4594"
+                d="m 73.476,26.669 c -5.869,0.062 -11.202,3.336 -11.202,3.336 l 0.682,-3.212 h -7.044 l -6.427,35.215 h 7.198 L 61.04,38.84 c 3.221,-6.544 11.182,-4.51 11.182,-4.51 z"
+                inkscape:connector-curvature="0"
+                style="stroke-width:1.67586744" />
+        <path
+                id="path4596"
+                d="m 46.014,11.578 c 0.364,0.275 0.709,0.566 1.048,0.863 l 5.462,-4.286 0.17,-0.222 C 51.858,7.088 50.96,6.289 49.986,5.554 37.452,-3.908 18.509,0.053 7.68,14.403 -3.148,28.75 -1.765,48.049 10.772,57.512 c 10.236,7.726 24.739,6.5 35.612,-2.018 l -0.011,-0.022 -5.2,-4.079 C 33.116,56.575 23.12,56.948 15.888,51.49 6.259,44.221 5.196,29.396 13.513,18.374 21.833,7.352 36.384,4.31 46.014,11.578 Z"
+                inkscape:connector-curvature="0"
+                style="stroke-width:1.67586744" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/src/services/EntryPersist.php
+++ b/src/services/EntryPersist.php
@@ -56,7 +56,6 @@ class EntryPersist extends Component
             if ($entry->type == 'event') {
                 //Todo extract this
                 $eventId = preg_replace('/\d+_{1}/', '', $entry->fbId);
-                $entry->has_detail = true;
                 try {
                     $event = FacebookConnector::$plugin->entryFetcher->getEventDetails($eventId);
                     $entry->event_cover_offset_y = $event->cover->offset_y;
@@ -69,6 +68,7 @@ class EntryPersist extends Component
                     echo 'event with id: ' . $eventId . ' could not be loaded (maybe its a shared object)';
                 }
             }
+            $entry->has_detail = true;
             $entry->update();
         }
         return $count;


### PR DESCRIPTION
## v1.2.0 - 2017-12-12
### Changed, going to the first Stable Major Vesion
 
 
## v1.1.0-rc.2 - 2017-12-09
### Fixed
   - Fixed a bug where shared events throws exception on requesting the event details, created new type `shared_event` for this case

