### PR TITLE
Bugfix/entry poster get post data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Unreleased
+## 1.2.5 - 2018-01-20
+### Fixed
+- Fixed a bug in EntryPoster that throws an exception when saving an entry
 
 ####  Released
 
+
 ## 1.2.4 - 2018-01-18
 ### Added
-   - Added CI configuration to the Project
-   - Dummy PHPUnit test 
+ - Added CI configuration to the Project
+ - Dummy PHPUnit test 
 ### Changed
-   - removed v from the version numbers
+ - removed v from the version numbers
 ### Fixed
-   - Fixed an issue with the configLoader   
+ - Fixed an issue with the configLoader   
 
 
 ## 1.2.3 - 2017-12-22
 ### Changed
-   - updated composer.json
+ - updated composer.json
 
 ## 1.2.0 - 2017-12-12
 ### Changed,
@@ -29,80 +33,80 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
  
 ## 1.1.0-rc.2 - 2017-12-09
 ### Fixed
-   - Fixed a bug where shared events throws exception on requesting the event details, created new type `shared_event` for this case
+ - Fixed a bug where shared events throws exception on requesting the event details, created new type `shared_event` for this case
 
 
 ## 1.1.0-rc.1 - 2017-12-07
 ### Added
-   - Event Deatail Data now also available 
+ - Event Deatail Data now also available 
 ### Updated
-   - Updated Readme.md    
+ - Updated Readme.md    
 
 ## 1.0.0-rc.1
 ## Added
-   - Updated readme, fixed code issues
+ - Updated readme, fixed code issues
 
 ## 0.18.0 - 2017-11-05
 ### Added
-   - Entries can now be Loaded from Facebook
-   - Added a craft variable to get the entries from the database
-   - Entries now "fechtable" with quries (like standard craft contents)
+ - Entries can now be Loaded from Facebook
+ - Added a craft variable to get the entries from the database
+ - Entries now "fechtable" with quries (like standard craft contents)
     
 ## 0.17.0 - 2017-11-02
-   - Started with Implementation of "fetch Facebook Feed" 
+ - Started with Implementation of "fetch Facebook Feed" 
 
 ## 0.16.0 - 2017-10-08
 ### Added
-  - Contribute Text
-  - Added Link to the Youtube Configuration description
+- Contribute Text
+- Added Link to the Youtube Configuration description
 ### Fixed
-  - Updated the Documentation how its possible to use functions in `fieldconfig.php` #13
+- Updated the Documentation how its possible to use functions in `fieldconfig.php` #13
   
 ### Changed
-  - Refactored the EntryPoster  
+- Refactored the EntryPoster  
   
 ## 0.15.0 - 2017-10-08
 ### Changed
-  - Readme Update
+- Readme Update
 
 ## 0.14.0 - 2017-09-25
 ### Added 
-  - First german Translations
-  - Added some lines of Doc
+- First german Translations
+- Added some lines of Doc
 
 ## 0.13.0 - 2017-09-25
 ### Fixed
-  - fixed codacy issues
+- fixed codacy issues
 
 ## 0.12.0 - 2017-09-25
 ### Changed
-  - renamed vendor of the project
+- renamed vendor of the project
 
 ## 0.11.0 - 2017-09-25
 ### Changed
-  - Moved the token callback function to the dashboard page, so no more templates are needed
+- Moved the token callback function to the dashboard page, so no more templates are needed
 
 ## 0.11.0 - 2017-09-25
 ### Added
-  - Boilerplate code added for the widget
+- Boilerplate code added for the widget
 
 ## 0.10.0 - 2017-09-25
 ### Added
-  - Entry field options can no be overwritten in the file fieldconfig.php
+- Entry field options can no be overwritten in the file fieldconfig.php
   
 ## 0.9.0 - 2017-09-24
 ### Added
-  - Options can now be defined in the plugin settings
+- Options can now be defined in the plugin settings
 
 ## 0.8.0 - 2017-09-24
 ### Changed
-   - Changed the readme and added som information's about the project
+ - Changed the readme and added som information's about the project
 
 ## 0.7.0 - 2017-09-22
 ### Added
-  - Implemented OAuth Login
-  - Implemented post to facebook
-  - Implemented update a post on facebook
+- Implemented OAuth Login
+- Implemented post to facebook
+- Implemented update a post on facebook
 
 ## 0.1.0 - 2017-09-16 (Initial Release)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Unreleased
+
+####  Released
 ## 1.2.5 - 2018-01-20
 ### Fixed
 - Fixed a bug in EntryPoster that throws an exception when saving an entry
-
-####  Released
-
 
 ## 1.2.4 - 2018-01-18
 ### Added

--- a/src/services/EntryPoster.php
+++ b/src/services/EntryPoster.php
@@ -73,11 +73,18 @@ class EntryPoster extends Component
     public function getPostData(Entry $entry)
     {
         $config = $this->configFileLoader->getConfigFile();
+        try {
+            $postOnFacebook = $entry->getFieldValue('post_on_facebook');
+            $message = $entry->getFieldValue('message');
+        } catch (\Exception $e) {
+            $postOnFacebook = false;
+            $message = false;
+        }
         $default = [
-            'post_on_facebook' => $entry->getFieldValue('post_on_facebook') ?? true,
+            'post_on_facebook' => $postOnFacebook,
             'link' => $entry->getUrl(),
             'entry_id' => $entry->id,
-            'message' => $entry->getFieldValue('message') ?? '',
+            'message' => $message,
             'picture' => '',
             'caption' => '',
             'description' => ''


### PR DESCRIPTION
## 1.2.5 - 2018-01-20
### Fixed
- Fixed a bug in EntryPoster that throws an exception when saving an entry