### PR TITLE
Remove roave/security-advisories from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     }
   ],
   "require": {
-    "roave/security-advisories": "dev-master",
     "craftcms/cms": "^3.0.0-RC1",
     "facebook/graph-sdk": "^5.6",
     "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
The Craft Plugin Store doesn't allow non-stable dependencies to be used (live dev-master), so this is causing a failure for anyone who tries to install the plugin.

If someone really wants to use roave/security-advisories, they should use it at their project's composer.json level.
